### PR TITLE
Enhance auth middleware and Express types for user roles

### DIFF
--- a/server/src/types/express/index.d.ts
+++ b/server/src/types/express/index.d.ts
@@ -1,14 +1,15 @@
-// types/express/index.d.ts
-import "express";
+import { UserRole } from "../../generated/prisma";
 
 declare global {
   namespace Express {
-    interface Request {
+    export interface Request {
       user?: {
         id: number;
         email: string;
-        role: string;
+        role: UserRole;
       };
     }
   }
 }
+
+export {};


### PR DESCRIPTION
Refactored auth middleware to validate and enforce UserRole type from Prisma, improving type safety and error handling for JWT payloads. Updated Express Request type definition to use UserRole, and moved/renamed the type declaration file for better organization.