### PR TITLE
Add protect and authorize middlewares for JWT auth

### DIFF
--- a/server/src/middlewares/auth.middleware.ts
+++ b/server/src/middlewares/auth.middleware.ts
@@ -1,7 +1,8 @@
-import { Request, Response, NextFunction } from "express";
-import { JWTUtil } from "../utils/jwt";
+import { NextFunction, Request, Response } from "express";
 import { AppError } from "../errors/app.error.js";
-import { User, UserRole } from "../generated/prisma";
+import { UserRole } from "../generated/prisma";
+import { JWTUtil } from "../utils/jwt";
+import jwt from "jsonwebtoken";
 
 export function authMiddleware(
   request: Request,
@@ -54,3 +55,37 @@ export function roleMiddleware(allowedRoles: string[]) {
     next();
   };
 }
+
+export const protect = (
+  request: Request,
+  response: Response,
+  next: NextFunction
+) => {
+  const token = request.header("Authorization")?.replace("Bearear ", "");
+
+  if (!token) {
+    throw new AppError("Akses ditolak, tidak ada token.", 401);
+  }
+
+  try {
+    const decoded = jwt.verify(
+      token,
+      process.env.JWT_SECRET || "your_default_secret"
+    );
+    request.user = decoded as Express.Request["user"];
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const authorize = (roles: UserRole[]) => {
+  return (request: Request, response: Response, next: NextFunction) => {
+    if (!request.user || !roles.includes(request.user.role)) {
+      throw new AppError(
+        "Anda tidak memiliki hak akses untuk sumber daya ini."
+      );
+    }
+    next();
+  };
+};


### PR DESCRIPTION
Introduces 'protect' middleware to verify JWT tokens and attach user info to requests, and 'authorize' middleware to restrict access based on user roles. Enhances authentication and authorization handling in the application.