### PR TITLE
Fix template string in getEventById API call

### DIFF
--- a/client/src/lib/api/events.ts
+++ b/client/src/lib/api/events.ts
@@ -27,7 +27,7 @@ export const getEvents = async (
 
 export const getEventById = async (id: number): Promise<TEventDetail> => {
   try {
-    const response = await api.get<{ data: TEventDetail }>("/events/${id}");
+    const response = await api.get<{ data: TEventDetail }>(`/events/${id}`);
     return response.data.data;
   } catch (error) {
     throw new Error("Failed to fetch event details");


### PR DESCRIPTION
Replaced incorrect string quotes with backticks in the getEventById function to properly interpolate the event ID in the API endpoint.